### PR TITLE
Feature/add note endpoints

### DIFF
--- a/lib/line_drive.ex
+++ b/lib/line_drive.ex
@@ -17,6 +17,7 @@ defmodule LineDrive do
   defdelegate create_lead(client, lead), to: LineDrive.Leads
 
   defdelegate add_note(client, note), to: LineDrive.Notes
+  defdelegate get_all_org_notes(client, org_id, opts), to: LineDrive.Notes
 
   defdelegate get_organization(client, org_id), to: LineDrive.Organizations
   defdelegate search_organizations(client, term, opts), to: LineDrive.Organizations

--- a/lib/line_drive.ex
+++ b/lib/line_drive.ex
@@ -12,6 +12,8 @@ defmodule LineDrive do
   defdelegate get_deal(client, deal_id), to: LineDrive.Deals
   defdelegate search_deals(client, term, opts), to: LineDrive.Deals
 
+  defdelegate add_note(client, note), to: LineDrive.Notes
+
   defdelegate get_organization(client, org_id), to: LineDrive.Organizations
   defdelegate search_organizations(client, term, opts), to: LineDrive.Organizations
   defdelegate create_organization(client, org), to: LineDrive.Organizations

--- a/lib/line_drive.ex
+++ b/lib/line_drive.ex
@@ -12,6 +12,10 @@ defmodule LineDrive do
   defdelegate get_deal(client, deal_id), to: LineDrive.Deals
   defdelegate search_deals(client, term, opts), to: LineDrive.Deals
 
+  defdelegate get_lead(client, lead_id), to: LineDrive.Leads
+  defdelegate search_leads(client, term, opts), to: LineDrive.Leads
+  defdelegate create_lead(client, lead), to: LineDrive.Leads
+
   defdelegate add_note(client, note), to: LineDrive.Notes
 
   defdelegate get_organization(client, org_id), to: LineDrive.Organizations
@@ -26,10 +30,6 @@ defmodule LineDrive do
   defdelegate list_pipeline_deals(client, pipeline_id), to: LineDrive.Pipelines
 
   defdelegate find_users_by_name(client, term, opts \\ []), to: LineDrive.Users
-
-  defdelegate get_lead(client, lead_id), to: LineDrive.Leads
-  defdelegate search_leads(client, term, opts), to: LineDrive.Leads
-  defdelegate create_lead(client, lead), to: LineDrive.Leads
 
   def client(api_token, base_url) do
     base_url = process_base(base_url)

--- a/lib/line_drive/note.ex
+++ b/lib/line_drive/note.ex
@@ -1,0 +1,42 @@
+defmodule LineDrive.Note do
+  @moduledoc """
+  This module and enclosed structs represent a note in pipedrive.
+  """
+
+  use TypedStruct
+
+  typedstruct do
+    field :content, String.t(), enforce: true
+    field :id, String.t()
+    field :org_id, pos_integer()
+    field :person_id, pos_integer()
+    field :deal_id, pos_integer()
+    field :lead_id, pos_integer()
+    field :pinned_to_organization_flag, boolean(), default: false
+  end
+
+  defimpl Jason.Encoder, for: __MODULE__ do
+    def encode(%{} = note, opts) do
+      Jason.Encode.value(
+        Map.take(Map.from_struct(note), [
+          :content,
+          :org_id,
+          :person_id,
+          :deal_id,
+          :lead_id,
+          :pinned_to_organization_flag
+        ]),
+        opts
+      )
+    end
+
+    def encode(note, opts), do: Jason.encode(note, opts)
+  end
+
+  def new(map) do
+    struct(
+      __MODULE__,
+      map
+    )
+  end
+end

--- a/lib/line_drive/notes.ex
+++ b/lib/line_drive/notes.ex
@@ -5,7 +5,6 @@ defmodule LineDrive.Notes do
 
   use Tesla
 
-  alias Hex.API.Key
   alias LineDrive.Note
   alias Tesla.Client
 

--- a/lib/line_drive/notes.ex
+++ b/lib/line_drive/notes.ex
@@ -1,0 +1,27 @@
+defmodule LineDrive.Notes do
+  @moduledoc """
+  This module encapsulates calls to the pipedrive notes resource API
+  """
+
+  use Tesla
+
+  alias LineDrive.Note
+  alias Tesla.Client
+
+  @callback add_note(Client.t(), Note.t()) :: {:ok, Note.t()}
+
+  def add_note(%Client{} = client, %Note{id: nil} = note) do
+    client
+    |> post("/api/v1/notes", note)
+    |> case do
+      {:ok, %Tesla.Env{status: 201, body: %{data: note_data}}} ->
+        {:ok, Note.new(note_data)}
+
+      {:ok, %Tesla.Env{body: %{success: false, error: message}}} ->
+        {:error, message}
+
+      {:error, env} ->
+        {:error, env}
+    end
+  end
+end

--- a/lib/line_drive/notes.ex
+++ b/lib/line_drive/notes.ex
@@ -5,10 +5,12 @@ defmodule LineDrive.Notes do
 
   use Tesla
 
+  alias Hex.API.Key
   alias LineDrive.Note
   alias Tesla.Client
 
   @callback add_note(Client.t(), Note.t()) :: {:ok, Note.t()}
+  @callback get_all_org_notes(Client.t(), binary()) :: {:ok, list(Note.t())}
 
   def add_note(%Client{} = client, %Note{id: nil} = note) do
     client
@@ -16,6 +18,31 @@ defmodule LineDrive.Notes do
     |> case do
       {:ok, %Tesla.Env{status: 201, body: %{data: note_data}}} ->
         {:ok, Note.new(note_data)}
+
+      {:ok, %Tesla.Env{body: %{success: false, error: message}}} ->
+        {:error, message}
+
+      {:error, env} ->
+        {:error, env}
+    end
+  end
+
+  def get_all_org_notes(%Client{} = client, org_id, opts \\ []) do
+    sort = Keyword.get(opts, :sort, "add_time DESC")
+    start = Keyword.get(opts, :start, 0)
+    limit = Keyword.get(opts, :limit, 20)
+
+    client
+    |> get("/api/v1/notes", query: [org_id: org_id, start: start, limit: limit, sort: sort])
+    |> case do
+      {:ok, %Tesla.Env{status: 200, body: %{success: true, data: data}}} ->
+        notes =
+          data
+          |> Enum.map(fn note_container ->
+            Note.new(note_container)
+          end)
+
+        {:ok, notes}
 
       {:ok, %Tesla.Env{body: %{success: false, error: message}}} ->
         {:error, message}

--- a/test/notes/add_note_test.exs
+++ b/test/notes/add_note_test.exs
@@ -1,0 +1,29 @@
+defmodule LineDrive.Notes.AddNoteTest do
+  @moduledoc false
+  use LineDrive.PipedriveClientCase, async: false
+
+  alias LineDrive.{
+    Notes,
+    Note
+  }
+
+  describe "add_note" do
+    test "it forms a correct request and returns an added note", %{client: client} do
+      expected_attributes = %{
+        content: "Met them at such and such event",
+        org_id: 1,
+        pinned_to_organization_flag: true
+      }
+
+      unsaved_note = Note.new(expected_attributes)
+
+      assert {:ok,
+              %Note{
+                id: 1,
+                content: "Met them at such and such event",
+                org_id: 1,
+                pinned_to_organization_flag: true
+              }} = Notes.add_note(client, unsaved_note)
+    end
+  end
+end

--- a/test/notes/add_note_test.exs
+++ b/test/notes/add_note_test.exs
@@ -3,8 +3,8 @@ defmodule LineDrive.Notes.AddNoteTest do
   use LineDrive.PipedriveClientCase, async: false
 
   alias LineDrive.{
-    Notes,
-    Note
+    Note,
+    Notes
   }
 
   describe "add_note" do

--- a/test/notes/get_all_org_notes_test.exs
+++ b/test/notes/get_all_org_notes_test.exs
@@ -1,0 +1,30 @@
+defmodule LineDrive.Notes.GetAllNotesTest do
+  @moduledoc false
+  use LineDrive.PipedriveClientCase, async: false
+
+  alias LineDrive.{
+    Note,
+    Notes
+  }
+
+  describe "get_all_org_notes" do
+    test "it forms a correct request and returns the correct data structure results for matching notes",
+         %{client: client} do
+      assert {:ok,
+              [
+                %Note{
+                  id: 2,
+                  org_id: 1,
+                  content: "Met them at such and such event",
+                  pinned_to_organization_flag: true
+                },
+                %Note{
+                  id: 1,
+                  org_id: 1,
+                  content: "Talked with them and they told me they are using elixir",
+                  pinned_to_organization_flag: false
+                }
+              ]} = Notes.get_all_org_notes(client, org_id: 1)
+    end
+  end
+end

--- a/test/support/fake_note_api_handler.ex
+++ b/test/support/fake_note_api_handler.ex
@@ -1,0 +1,45 @@
+defmodule LineDrive.FakeNoteApiHandler do
+  @moduledoc false
+
+  import Plug.Conn
+
+  def handle_add_note(%{body_params: %{"content" => "Met them at such and such event"}} = conn) do
+    response_body = ~s"""
+    {
+      "success": true,
+      "data": {
+          "id": 1,
+          "user_id": 17120881,
+          "deal_id": null,
+          "person_id": null,
+          "org_id": 1,
+          "lead_id": null,
+          "content": "Met them at such and such event",
+          "add_time": "2023-02-14 21:15:32",
+          "update_time": "2023-02-14 21:15:32",
+          "active_flag": true,
+          "pinned_to_deal_flag": false,
+          "pinned_to_person_flag": false,
+          "pinned_to_organization_flag": true,
+          "pinned_to_lead_flag": false,
+          "last_update_user_id": null,
+          "organization": {
+              "name": "Mecklem, LLC"
+          },
+          "person": null,
+          "deal": null,
+          "lead": null,
+          "user": {
+              "email": "steveloar@launchscout.com",
+              "name": "Steve Loar",
+              "icon_url": null,
+              "is_you": true
+          }
+      }
+    }
+    """
+
+    conn
+    |> send_resp(201, response_body)
+  end
+end

--- a/test/support/fake_note_api_handler.ex
+++ b/test/support/fake_note_api_handler.ex
@@ -9,7 +9,7 @@ defmodule LineDrive.FakeNoteApiHandler do
       "success": true,
       "data": {
           "id": 1,
-          "user_id": 17120881,
+          "user_id": 123,
           "deal_id": null,
           "person_id": null,
           "org_id": 1,
@@ -30,8 +30,8 @@ defmodule LineDrive.FakeNoteApiHandler do
           "deal": null,
           "lead": null,
           "user": {
-              "email": "steveloar@launchscout.com",
-              "name": "Steve Loar",
+              "email": "person@launchscout.com",
+              "name": "Person",
               "icon_url": null,
               "is_you": true
           }
@@ -41,5 +41,84 @@ defmodule LineDrive.FakeNoteApiHandler do
 
     conn
     |> send_resp(201, response_body)
+  end
+
+  def handle_get_all_org_notes(conn, %{"org_id" => _org_id}) do
+    response_body = ~s"""
+    {
+      "success": true,
+      "data": [
+          {
+              "id": 2,
+              "user_id": 123,
+              "deal_id": null,
+              "person_id": null,
+              "org_id": 1,
+              "lead_id": null,
+              "content": "Met them at such and such event",
+              "add_time": "2023-02-14 21:15:32",
+              "update_time": "2023-02-14 21:15:32",
+              "active_flag": true,
+              "pinned_to_deal_flag": false,
+              "pinned_to_person_flag": false,
+              "pinned_to_organization_flag": true,
+              "pinned_to_lead_flag": false,
+              "last_update_user_id": null,
+              "organization": {
+                  "name": "Mecklem, LLC"
+              },
+              "person": null,
+              "deal": null,
+              "lead": null,
+              "user": {
+                  "email": "person@launchscout.com",
+                  "name": "Person",
+                  "icon_url": null,
+                  "is_you": false
+              }
+          },
+          {
+            "id": 1,
+            "user_id": 123,
+            "deal_id": null,
+            "person_id": null,
+            "org_id": 1,
+            "lead_id": null,
+            "content": "Talked with them and they told me they are using elixir",
+            "add_time": "2023-02-14 20:58:31",
+            "update_time": "2023-02-14 21:13:18",
+            "active_flag": true,
+            "pinned_to_deal_flag": false,
+            "pinned_to_person_flag": false,
+            "pinned_to_organization_flag": false,
+            "pinned_to_lead_flag": false,
+            "last_update_user_id": null,
+            "organization": {
+                "name": "Mecklem, LLC"
+            },
+            "person": null,
+            "deal": null,
+            "lead": null,
+            "user": {
+                "email": "person@launchscout.com",
+                "name": "Person",
+                "icon_url": null,
+                "is_you": false
+            }
+        }
+      ],
+      "additional_data": {
+          "pagination": {
+              "start": 0,
+              "limit": 2,
+              "more_items_in_collection": true,
+              "next_start": 3
+          }
+      }
+    }
+    """
+
+    conn
+    |> send_resp(200, response_body)
   end
 end

--- a/test/support/fake_pipedrive_server.ex
+++ b/test/support/fake_pipedrive_server.ex
@@ -57,6 +57,12 @@ defmodule LineDrive.FakePipedriveServer do
     |> handle_add_note()
   end
 
+  get "/api/v1/notes" do
+    conn
+    |> put_resp_header("content-type", "application/json;charset=utf-8")
+    |> handle_get_all_org_notes(conn.query_params)
+  end
+
   get "/api/v1/organizations/search" do
     conn
     |> put_resp_header("content-type", "application/json;charset=utf-8")

--- a/test/support/fake_pipedrive_server.ex
+++ b/test/support/fake_pipedrive_server.ex
@@ -10,6 +10,7 @@ defmodule LineDrive.FakePipedriveServer do
     FakeActivityApiHandler,
     FakeActivityTypeApiHandler,
     FakeDealApiHandler,
+    FakeNoteApiHandler,
     FakeOrganizationApiHandler,
     FakeLeadApiHandler,
     FakePersonApiHandler,
@@ -48,6 +49,12 @@ defmodule LineDrive.FakePipedriveServer do
     conn
     |> put_resp_header("content-type", "application/json;charset=utf-8")
     |> handle_get_deal(conn.params)
+  end
+
+  post "/api/v1/notes" do
+    conn
+    |> put_resp_header("content-type", "application/json;charset=utf-8")
+    |> handle_add_note()
   end
 
   get "/api/v1/organizations/search" do


### PR DESCRIPTION
This work sets up the add_note endpoint which will be initially used in creating Notes for new Organizations. It also includes get_all_org_notes endpoint to get all notes related to an organization.