### PR TITLE
Feature/organization fields

### DIFF
--- a/lib/line_drive.ex
+++ b/lib/line_drive.ex
@@ -19,6 +19,8 @@ defmodule LineDrive do
   defdelegate add_note(client, note), to: LineDrive.Notes
   defdelegate get_all_org_notes(client, org_id, opts), to: LineDrive.Notes
 
+  defdelegate get_org_field_keys_and_names(client, opts), to: LineDrive.OrganizationFields
+
   defdelegate get_organization(client, org_id), to: LineDrive.Organizations
   defdelegate search_organizations(client, term, opts), to: LineDrive.Organizations
   defdelegate create_organization(client, org), to: LineDrive.Organizations

--- a/lib/line_drive/organization_field.ex
+++ b/lib/line_drive/organization_field.ex
@@ -1,0 +1,53 @@
+defmodule LineDrive.OrganizationField do
+  @moduledoc """
+  This module and enclosed structs represent an organization field in pipedrive.
+  """
+
+  use TypedStruct
+
+  typedstruct do
+    field :id, pos_integer()
+    field :key, String.t()
+    field :name, String.t()
+    field :order_nr, pos_integer()
+    field :field_type, String.t()
+    field :json_column_flag, boolean()
+    field :add_time, Date.t()
+    field :update_time, Date.t()
+    field :last_updated_by_user_id, pos_integer()
+    field :edit_flag, boolean()
+    field :details_visible_flag, boolean()
+    field :add_visible_flag, boolean()
+    field :important_flag, boolean()
+    field :bulk_edit_allowed, boolean()
+    field :filtering_allowed, boolean()
+    field :sortable_flag, boolean()
+    field :mandatory_flag, boolean()
+    field :link, String.t()
+    field :use_field, String.t()
+    field :active_flag, boolean()
+    field :index_visible_flag, boolean()
+    field :searchable_flag, boolean()
+  end
+
+  defimpl Jason.Encoder, for: __MODULE__ do
+    def encode(%{} = organization_field, opts) do
+      Jason.Encode.value(
+        Map.take(Map.from_struct(organization_field), [
+          :key,
+          :name
+        ]),
+        opts
+      )
+    end
+
+    def encode(organization_field, opts), do: Jason.encode(organization_field, opts)
+  end
+
+  def new(map) do
+    struct(
+      __MODULE__,
+      map
+    )
+  end
+end

--- a/lib/line_drive/organization_fields.ex
+++ b/lib/line_drive/organization_fields.ex
@@ -1,0 +1,35 @@
+defmodule LineDrive.OrganizationFields do
+  @moduledoc """
+  This module encapsulates calls to the pipedrive organization fields resource API
+  """
+
+  use Tesla
+
+  alias LineDrive.OrganizationField
+  alias Tesla.Client
+
+  @callback get_org_field_keys_and_names(Client.t(), binary()) :: {:ok, OrganizationField.t()}
+
+  def get_org_field_keys_and_names(%Client{} = client, opts \\ []) do
+    start = Keyword.get(opts, :start, 0)
+    limit = Keyword.get(opts, :limit, 200)
+
+    client
+    |> get("/api/v1/organizationFields/", query: [start: start, limit: limit])
+    |> case do
+      {:ok, %Tesla.Env{status: 200, body: %{success: true, data: data}}} ->
+        org_fields =
+          data
+          |> Enum.map(fn item -> Map.take(item, [:key, :name]) end)
+          |> Enum.map(fn item -> OrganizationField.new(item) end)
+
+        {:ok, org_fields}
+
+      {:ok, %Tesla.Env{body: %{success: false, error: message}}} ->
+        {:error, message}
+
+      {:error, env} ->
+        {:error, env}
+    end
+  end
+end

--- a/lib/line_drive/organization_fields.ex
+++ b/lib/line_drive/organization_fields.ex
@@ -20,8 +20,11 @@ defmodule LineDrive.OrganizationFields do
       {:ok, %Tesla.Env{status: 200, body: %{success: true, data: data}}} ->
         org_fields =
           data
-          |> Enum.map(fn item -> Map.take(item, [:key, :name]) end)
-          |> Enum.map(fn item -> OrganizationField.new(item) end)
+          |> Enum.map(fn item ->
+            item
+            |> Map.take([:key, :name])
+            |> OrganizationField.new()
+          end)
 
         {:ok, org_fields}
 

--- a/test/organization_fields/get_org_keys_and_names_test.exs
+++ b/test/organization_fields/get_org_keys_and_names_test.exs
@@ -1,0 +1,26 @@
+defmodule LineDrive.OrganizationFields.GetOrgFieldKeysAndNamesTest do
+  @moduledoc false
+  use LineDrive.PipedriveClientCase, async: false
+
+  alias LineDrive.{
+    OrganizationField,
+    OrganizationFields
+  }
+
+  describe "get_org_field_keys_and_names" do
+    test "it forms a correct request and returns the correct data structure results for matching organization fields",
+         %{client: client} do
+      assert {:ok,
+              [
+                %OrganizationField{
+                  key: "name",
+                  name: "Name"
+                },
+                %OrganizationField{
+                  key: "93fc28f7d5aee87fc6484441cab648760a6c0d2d",
+                  name: "Tech Stack"
+                }
+              ]} = OrganizationFields.get_org_field_keys_and_names(client)
+    end
+  end
+end

--- a/test/support/fake_organization_field_api_handler.ex
+++ b/test/support/fake_organization_field_api_handler.ex
@@ -1,0 +1,71 @@
+defmodule LineDrive.FakeOrganizationFieldApiHandler do
+  @moduledoc false
+
+  import Plug.Conn
+
+  def handle_get_org_field_keys_and_names(conn, _opts) do
+    response_body = ~s"""
+    {
+      "success": true,
+      "data": [
+        {
+          "id": 4002,
+          "key": "name",
+          "name": "Name",
+          "order_nr": 1,
+          "field_type": "varchar",
+          "json_column_flag": false,
+          "add_time": "2022-08-22 21:35:48",
+          "update_time": "2022-08-22 21:35:48",
+          "last_updated_by_user_id": null,
+          "edit_flag": false,
+          "details_visible_flag": false,
+          "add_visible_flag": true,
+          "important_flag": false,
+          "bulk_edit_allowed": true,
+          "filtering_allowed": true,
+          "sortable_flag": true,
+          "mandatory_flag": true,
+          "link": "/organization/",
+          "use_field": "id",
+          "active_flag": true,
+          "index_visible_flag": true,
+          "searchable_flag": false
+        },
+        {
+          "id": 4024,
+          "key": "93fc28f7d5aee87fc6484441cab648760a6c0d2d",
+          "name": "Tech Stack",
+          "order_nr": 23,
+          "field_type": "varchar",
+          "json_column_flag": true,
+          "add_time": "2023-02-15 16:36:27",
+          "update_time": "2023-02-15 16:36:26",
+          "last_updated_by_user_id": 1,
+          "edit_flag": true,
+          "details_visible_flag": true,
+          "add_visible_flag": true,
+          "important_flag": true,
+          "bulk_edit_allowed": true,
+          "filtering_allowed": true,
+          "sortable_flag": true,
+          "mandatory_flag": false,
+          "active_flag": true,
+          "index_visible_flag": true,
+          "searchable_flag": true
+        }
+      ],
+      "additional_data": {
+          "pagination": {
+              "start": 0,
+              "limit": 500,
+              "more_items_in_collection": false
+          }
+      }
+    }
+    """
+
+    conn
+    |> send_resp(200, response_body)
+  end
+end

--- a/test/support/fake_pipedrive_server.ex
+++ b/test/support/fake_pipedrive_server.ex
@@ -11,6 +11,7 @@ defmodule LineDrive.FakePipedriveServer do
     FakeActivityTypeApiHandler,
     FakeDealApiHandler,
     FakeNoteApiHandler,
+    FakeOrganizationFieldApiHandler,
     FakeOrganizationApiHandler,
     FakeLeadApiHandler,
     FakePersonApiHandler,
@@ -61,6 +62,12 @@ defmodule LineDrive.FakePipedriveServer do
     conn
     |> put_resp_header("content-type", "application/json;charset=utf-8")
     |> handle_get_all_org_notes(conn.query_params)
+  end
+
+  get "/api/v1/organizationFields/" do
+    conn
+    |> put_resp_header("content-type", "application/json;charset=utf-8")
+    |> handle_get_org_field_keys_and_names(conn.params)
   end
 
   get "/api/v1/organizations/search" do


### PR DESCRIPTION
This work pulls key and name values from the OrganizationFields endpoint of the Pipe Drive API. It is required for finding the keys needed to save the values for custom fields.