### PR TITLE
Reduce Organization Field struct to key and name

### DIFF
--- a/lib/line_drive/organization_field.ex
+++ b/lib/line_drive/organization_field.ex
@@ -6,28 +6,8 @@ defmodule LineDrive.OrganizationField do
   use TypedStruct
 
   typedstruct do
-    field :id, pos_integer()
     field :key, String.t()
     field :name, String.t()
-    field :order_nr, pos_integer()
-    field :field_type, String.t()
-    field :json_column_flag, boolean()
-    field :add_time, Date.t()
-    field :update_time, Date.t()
-    field :last_updated_by_user_id, pos_integer()
-    field :edit_flag, boolean()
-    field :details_visible_flag, boolean()
-    field :add_visible_flag, boolean()
-    field :important_flag, boolean()
-    field :bulk_edit_allowed, boolean()
-    field :filtering_allowed, boolean()
-    field :sortable_flag, boolean()
-    field :mandatory_flag, boolean()
-    field :link, String.t()
-    field :use_field, String.t()
-    field :active_flag, boolean()
-    field :index_visible_flag, boolean()
-    field :searchable_flag, boolean()
   end
 
   defimpl Jason.Encoder, for: __MODULE__ do

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@ defmodule LineDrive.MixProject do
       elixirc_paths: elixirc_paths(Mix.env()),
       package: package(),
       start_permanent: Mix.env() == :prod,
-      version: "0.16.0"
+      version: "0.17.0"
     ]
   end
 


### PR DESCRIPTION
Removing unused Organization Fields from the struct. We only pass and use the key and name.