### PR TITLE
Add user_id, done, and type to list_activities parameters

### DIFF
--- a/lib/line_drive/activities.ex
+++ b/lib/line_drive/activities.ex
@@ -33,7 +33,9 @@ defmodule LineDrive.Activities do
       {:cursor, :cursor, nil},
       {:since, :since, nil},
       {:until, :until, nil},
-      {:owner_id, :user_id, nil}
+      {:user_id, :user_id, nil},
+      {:done, :done, nil},
+      {:type, :type, nil}
     ]
 
     params =

--- a/lib/line_drive/activities.ex
+++ b/lib/line_drive/activities.ex
@@ -53,6 +53,13 @@ defmodule LineDrive.Activities do
         params
       end
 
+    params =
+      if owner_id = Keyword.get(opts, :owner_id) do
+        [{:user_id, owner_id} | params]
+      else
+        params
+      end
+
     client
     |> get("/api/v1/activities/collection", query: params)
     |> case do

--- a/lib/line_drive/activities.ex
+++ b/lib/line_drive/activities.ex
@@ -28,37 +28,21 @@ defmodule LineDrive.Activities do
   end
 
   def list_activities(%Client{} = client, opts \\ []) do
-    params = [
-      limit: Keyword.get(opts, :limit, 100)
+    param_mappings = [
+      {:limit, :limit, 100},
+      {:cursor, :cursor, nil},
+      {:since, :since, nil},
+      {:until, :until, nil},
+      {:owner_id, :user_id, nil}
     ]
 
     params =
-      if cursor = Keyword.get(opts, :cursor) do
-        [{:cursor, cursor} | params]
-      else
-        params
-      end
-
-    params =
-      if since = Keyword.get(opts, :since) do
-        [{:since, since} | params]
-      else
-        params
-      end
-
-    params =
-      if until = Keyword.get(opts, :until) do
-        [{:until, until} | params]
-      else
-        params
-      end
-
-    params =
-      if owner_id = Keyword.get(opts, :owner_id) do
-        [{:user_id, owner_id} | params]
-      else
-        params
-      end
+      Enum.reduce(param_mappings, [], fn {opt_key, param_key, default}, params ->
+        case Keyword.get(opts, opt_key, default) do
+          nil -> params
+          value -> [{param_key, value} | params]
+        end
+      end)
 
     client
     |> get("/api/v1/activities/collection", query: params)

--- a/test/activities/list_activities_test.exs
+++ b/test/activities/list_activities_test.exs
@@ -28,12 +28,27 @@ defmodule LineDrive.Activities.ListActivitiesTest do
                )
     end
 
-    test "it accepts cursor, limit, and owner_id parameters", %{client: client} do
+    test "it accepts cursor, limit, and user_id parameters", %{client: client} do
       assert {:ok, %PagedResult{success: true}} =
                Activities.list_activities(client,
                  cursor: "MTIzNDU2Nzg5MA==",
                  limit: 50,
-                 owner_id: 123
+                 user_id: 123
+               )
+    end
+
+    test "it accepts done and type parameters", %{client: client} do
+      assert {:ok, %PagedResult{success: true}} =
+               Activities.list_activities(client,
+                 done: true,
+                 type: "call"
+               )
+    end
+
+    test "it accepts multiple types as comma-separated string", %{client: client} do
+      assert {:ok, %PagedResult{success: true}} =
+               Activities.list_activities(client,
+                 type: "call,meeting"
                )
     end
   end

--- a/test/activities/list_activities_test.exs
+++ b/test/activities/list_activities_test.exs
@@ -27,5 +27,14 @@ defmodule LineDrive.Activities.ListActivitiesTest do
                  limit: 50
                )
     end
+
+    test "it accepts cursor, limit, and owner_id parameters", %{client: client} do
+      assert {:ok, %PagedResult{success: true}} =
+               Activities.list_activities(client,
+                 cursor: "MTIzNDU2Nzg5MA==",
+                 limit: 50,
+                 owner_id: 123
+               )
+    end
   end
 end


### PR DESCRIPTION
I mistakenly thought we were using the V2 of the API, which uses owner_id and not user_id. I've renamed to user_id so that we are consistent with the v1 API